### PR TITLE
Add commit minimum age requirement

### DIFF
--- a/src/CurtaGolf.sol
+++ b/src/CurtaGolf.sol
@@ -26,7 +26,7 @@ contract CurtaGolf is ICurtaGolf, KingERC721, Owned {
 
     /// @notice The maximum number of seconds that must pass before a commit can
     /// be revealed.
-    uint256 constant MIN_COMMIT_AGE = 255;
+    uint256 constant MIN_COMMIT_AGE = 60;
 
     // -------------------------------------------------------------------------
     // Immutable storage
@@ -76,7 +76,7 @@ contract CurtaGolf is ICurtaGolf, KingERC721, Owned {
         if (getCommit[_key].player != address(0)) revert KeyAlreadyCommitted(_key);
 
         // Commit the key.
-        getCommit[_key] = Commit({ player: msg.sender, blockNumber: uint96(block.number) });
+        getCommit[_key] = Commit({ player: msg.sender, timestamp: uint96(block.timestamp) });
     }
 
     /// @inheritdoc ICurtaGolf
@@ -92,7 +92,9 @@ contract CurtaGolf is ICurtaGolf, KingERC721, Owned {
 
         // Revert if the commit is too new.
         unchecked {
-            if (commit.blockNumber + MIN_COMMIT_AGE < block.timestamp) revert CommitTooNew(key);
+            if (uint256(commit.timestamp) + MIN_COMMIT_AGE > block.timestamp) {
+                revert CommitTooNew(key);
+            }
         }
 
         _submit(_courseId, _solution, _recipient);

--- a/src/interfaces/ICurtaGolf.sol
+++ b/src/interfaces/ICurtaGolf.sol
@@ -46,10 +46,10 @@ interface ICurtaGolf {
     /// @notice A struct containing data about a submission's commit.
     /// @param player The address of the player (i.e. the address that is making
     /// the commit and the submission).
-    /// @param blockNumber The block number of the commit.
+    /// @param timestamp The block timestamp the commit was posted.
     struct Commit {
         address player;
-        uint96 blockNumber;
+        uint96 timestamp;
     }
 
     /// @notice A struct containing data about a course.
@@ -122,8 +122,8 @@ interface ICurtaGolf {
     /// @param _key The key of the commit.
     /// @return player The address of the player (i.e. the address that is
     /// making the commit and the submission).
-    /// @return blockNumber The block number of the commit.
-    function getCommit(bytes32 _key) external view returns (address player, uint96 blockNumber);
+    /// @return timestamp The block timestamp the commit was posted.
+    function getCommit(bytes32 _key) external view returns (address player, uint96 timestamp);
 
     /// @param _id The ID of the course.
     /// @param solutionCount The number of successful solutions submitted.


### PR DESCRIPTION
- Adds commit minimum age requirement of `60` seconds (configurable w/ constant `COMMIT_MIN_AGE` in `CurtaGolf.sol:CurtaGolf`)
- Refactors/updates commit to be timestamped by `block.timestamp`, rather than `block.number` + update relevant docs/comments