### PR TITLE
remove `libraries` from `foundry.toml`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: workflow_dispatch
+on: [push]
 
 env:
   FOUNDRY_PROFILE: ci

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ forge coverage --report lcov
 
 ## Deploying
 
-There are three core contracts that get deployed in [`Deploy.s.sol`](https://github.com/waterfall-mkt/curta-golf/blob/main/script/Deploy.s.sol): `PurityChecker.sol`, `Par.sol`, and `CurtaGolf.sol`. We also make use of three external libraries included in [`foundry.toml`](https://github.com/waterfall-mkt/curta-golf/blob/main/foundry.toml#L16-L20C2). These are: `Perlin.sol`, `ParArt.sol`, and `KingArt.sol`. `Perlin.sol` is used by `KingArt.sol`, which is used by `KingERC721.sol`, which is inherited by `CurtaGolf.sol`, and `ParArt.sol` is used by `Par.sol`. We include these in `foundry.toml` if we *don't* want them to be deployed alongside the contracts that use them. Otherwise, as an example, `Perlin.sol` and `KingArt.sol` would be deployed alongside `CurtaGolf.sol`.
+There are three core contracts that get deployed in [`Deploy.s.sol`](https://github.com/waterfall-mkt/curta-golf/blob/main/script/Deploy.s.sol): `PurityChecker.sol`, `Par.sol`, and `CurtaGolf.sol`. We also make use of three external libraries. These are: `Perlin.sol`, `ParArt.sol`, and `KingArt.sol`. `Perlin.sol` is used by `KingArt.sol`, which is used by `KingERC721.sol`, which is inherited by `CurtaGolf.sol`, and `ParArt.sol` is used by `Par.sol`. We include these in `foundry.toml` if we *don't* want them to be deployed alongside the contracts that use them. Otherwise, as an example, `Perlin.sol` and `KingArt.sol` would be deployed alongside `CurtaGolf.sol`.
 
 A standard example for deploying everything would look like this:
 ```sh

--- a/foundry.toml
+++ b/foundry.toml
@@ -11,15 +11,6 @@ remappings = [
     'solmate/=lib/solmate/src/',
 ]
 
-# These external libraries have already been so we reference them this way
-# They would otherwise be deployed again via the contracts that use them.
-libraries = [
-    "src/utils/Perlin.sol:Perlin:0x5499e963931d359553380bCA52077ecB0E2419d6",
-    "src/utils/metadata/KingArt.sol:KingArt:0xcD1842728b73611445c87801889CAE24CF5502c6",
-    "src/utils/metadata/ParArt.sol:ParArt:0xBc475ce743B5C331A62d55Ce19A83De47d978e1C"
-]
-
-
 [fmt]
 line_length = 100
 tab_width = 4


### PR DESCRIPTION
The `libraries` var in `foundry.toml` was leading to two broken tests.
![image](https://github.com/waterfall-mkt/curta-golf/assets/24715302/fc5e7911-1816-412c-835a-25dbdb0fe30f)
There was already a possible issue that this posed where we wanted to deploy the entire protocol this would result in skipping the deploy of the external libraries to be used so it has be removed entirely. The language in the `README.md` has also been updated accordingly.

Also, the `test` workflow has been updated to run on `push` instead of manually to catch this in future PR's.