### PR TITLE
fix(purity): remove `submitDirectly`

### DIFF
--- a/script/metadata/PrintKingArt.s.sol
+++ b/script/metadata/PrintKingArt.s.sol
@@ -12,11 +12,19 @@ import { BaseTest } from "test/utils/BaseTest.sol";
 /// tokens, as outputted by {KingArt}.
 /// @dev Must be compiled with `--via-ir` to avoid stack too deep errors.
 contract PrintKingArtScript is BaseTest, Script {
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    /// @notice The address of the recipient of the solution.
+    address constant RECIPIENT = 0xA85572Cd96f1643458f17340b6f0D6549Af482F5;
+
     function setUp() public override {
         super.setUp();
 
         // Submit a solution to course #1 as `fiveoutofnine.eth`.
-        curtaGolf.submitDirectly(1, EFFICIENT_SOLUTION, 0xA85572Cd96f1643458f17340b6f0D6549Af482F5);
+        curtaGolf.commit(keccak256(abi.encode(RECIPIENT, EFFICIENT_SOLUTION, 0)));
+        curtaGolf.submit(1, EFFICIENT_SOLUTION, RECIPIENT, 0);
     }
     // -------------------------------------------------------------------------
     // `run`

--- a/script/metadata/PrintParArt.s.sol
+++ b/script/metadata/PrintParArt.s.sol
@@ -21,7 +21,8 @@ contract PrintParArtScript is BaseTest, Script {
         super.setUp();
 
         // Submit a solution to course #1 as `RECIPIENT`.
-        curtaGolf.submitDirectly(1, EFFICIENT_SOLUTION, RECIPIENT);
+        curtaGolf.commit(keccak256(abi.encode(RECIPIENT, EFFICIENT_SOLUTION, 0)));
+        curtaGolf.submit(1, EFFICIENT_SOLUTION, RECIPIENT, 0);
     }
     // -------------------------------------------------------------------------
     // `run`

--- a/src/CurtaGolf.sol
+++ b/src/CurtaGolf.sol
@@ -114,14 +114,6 @@ contract CurtaGolf is ICurtaGolf, KingERC721, Owned {
         return _submit(_courseId, _solution, _recipient);
     }
 
-    /// @inheritdoc ICurtaGolf
-    function submitDirectly(uint32 _courseId, bytes memory _solution, address _recipient)
-        external
-        returns (uint32)
-    {
-        return _submit(_courseId, _solution, _recipient);
-    }
-
     // -------------------------------------------------------------------------
     // `owner`-only functions
     // -------------------------------------------------------------------------

--- a/src/interfaces/ICurtaGolf.sol
+++ b/src/interfaces/ICurtaGolf.sol
@@ -193,15 +193,4 @@ interface ICurtaGolf {
     function submit(uint32 _courseId, bytes memory _solution, address _recipient, uint256 _salt)
         external
         returns (uint32);
-
-    /// @notice Submits a solution to a course directly, skipping the 2-step
-    /// commit-reveal process. Only call this function if front-running is not
-    /// a concern (e.g. the solution is not to become the leading solution).
-    /// @param _courseId The ID of the course.
-    /// @param _solution The bytecode of the solution.
-    /// @param _recipient The address of the recipient.
-    /// @return The gas used by the solution.
-    function submitDirectly(uint32 _courseId, bytes memory _solution, address _recipient)
-        external
-        returns (uint32);
 }


### PR DESCRIPTION
This PR depends on #19 

## Overview
For the first `curta-golf` course, it was possible for solvers to get a block's `PREVRANDAO` value in the same transaction that they submit their solution by using `submitDirectly`. Therefore, this PR will deprecate the function in which all solvers will need to use the commit-reveal scheme provided by `commit` + `submit`. This is not vulnerable to the above method since any call to `submit` will [check](https://github.com/waterfall-mkt/curta-golf/blob/b7ce5ecd42e85b8e5db8b8ce8ae7313a4659c14c/src/CurtaGolf.sol#L107-112) that `block.timestamp` has been increased by at least `60` before calls to `submit` succeed, ensuring that a solver's call to `submit` cannot come in the same block as the call to `commit`.

## Fixes
### `ICurtaGolf.sol`
* Removes the `submitDirectly` function signature.

### `CurtaGolf.sol`
* Removes the `submitDirectly` function.

### `CurtaGolf.t.sol`
* Removes the tests for `submitDirectly`.
* Modifies the test `test_tokenURI_MintedToken_Succeeds` to use `commit` + `submit`.

### `PrintKingArt.s.sol`
* `setUp` has been modified to use the `commit` + `submit` method instead of `submitDirectly`.
* This file was also missing the `RECIPIENT` constant present in `PrintParArt.s.sol` and has been added.

### `PrintParArt.s.sol`
* `setUp` has been modified to use the `commit` + `submit` method instead of `submitDirectly`.