### PR TITLE
fix(purity): modify `_submit` to check both initcode and runtime

### DIFF
--- a/src/CurtaGolf.sol
+++ b/src/CurtaGolf.sol
@@ -191,13 +191,18 @@ contract CurtaGolf is ICurtaGolf, KingERC721, Owned {
         // Revert if the course does not exist.
         if (address(courseData.course) == address(0)) revert CourseDoesNotExist(_courseId);
 
+        // Revert if the initcode contains invalid opcodes.
+        if (!purityChecker.check(_solution, getAllowedOpcodes[_courseId])) {
+            revert PollutedSolution();
+        }
+
         // Deploy the solution.
         address target;
         assembly {
             target := create(0, add(_solution, 0x20), mload(_solution))
         }
 
-        // Revert if the solution contains invalid opcodes.
+        // Revert if the runtime contains invalid opcodes.
         if (!purityChecker.check(target.code, getAllowedOpcodes[_courseId])) {
             revert PollutedSolution();
         }

--- a/src/CurtaGolf.sol
+++ b/src/CurtaGolf.sol
@@ -191,15 +191,15 @@ contract CurtaGolf is ICurtaGolf, KingERC721, Owned {
         // Revert if the course does not exist.
         if (address(courseData.course) == address(0)) revert CourseDoesNotExist(_courseId);
 
-        // Revert if the solution contains invalid opcodes.
-        if (!purityChecker.check(_solution, getAllowedOpcodes[_courseId])) {
-            revert PollutedSolution();
-        }
-
         // Deploy the solution.
         address target;
         assembly {
             target := create(0, add(_solution, 0x20), mload(_solution))
+        }
+
+        // Revert if the solution contains invalid opcodes.
+        if (!purityChecker.check(target.code, getAllowedOpcodes[_courseId])) {
+            revert PollutedSolution();
         }
 
         // Run solution and mint NFT if it beats the leading score.


### PR DESCRIPTION
This PR depends on #19 

## Overview
Contracts possess both a `creationCode` and a `runtimeCode`. At a high level, it is the job of the `creationCode` to load the `runtimeCode` into memory and then return it, in turn creating the contract. The `_submit` function runs the `PurityChecker` on the `creationCode` but not the `runtimeCode` introducing two ways to include illegal opcodes in the final runtime.
1. First, illegal opcodes could be arithmetically computed and then stored in memory using `MSTORE8`.
2. Second, the `PurityChecker` does not iterate over the bytes after pushes and instead increments the offset by the appropriate number of bytes and continues iteration. This makes it possible to push values to the stack that contain the illegal opcodes which then may be stored in memory.

It is not simply enough to check the `runtimeCode` and not the `creationCode` since not checking the latter would allow for a solver to precompute the values in the `creationCode` itself since in `_submit` the solution's deployment to `_target` occurs in the same execution environment as the call to `run` on the challenge. Since we don't want to sacrifice UX by separating these into different transactions, for a total of three for the solver to submit, we've opted to check both `creationCode` and `runtimeCode` within `_submit`.

## Fixes
### `CurtaGolf.sol`
* Modifies the call to the `PurityChecker` to check against the solution's runtime (`target.code`) in addition to the initcode, the `_solution` param.
* This check has thus been moved from before to after the deployment of `_solution` to `target` accordingly.